### PR TITLE
SHIFT SEARCH: Outter wrapper should respect redirect tag filtering

### DIFF
--- a/src/lib/algolia-outer-wrapper.js
+++ b/src/lib/algolia-outer-wrapper.js
@@ -38,7 +38,7 @@ export default function algoliaOuterWrapper (NextWrapper, Page) {
         searchState = Page.buildAlgoliaStates(appContext)
       }
       // We should always configure this in the state to prevent a onSearchStateChange first render
-      searchState.configure = { ...searchState.configure, hitsPerPage: Config.get().algoliaResultsPerPage, distinct: MAX_VARIANTS_PER_PRODUCT }
+      searchState.configure = { ...searchState.configure, hitsPerPage: Config.get().algoliaResultsPerPage, distinct: MAX_VARIANTS_PER_PRODUCT, tagFilters: "-redirect" }
 
       let resultsState = {
         _originalResponse: {


### PR DESCRIPTION
### Description

This change will prevent us seeing any redirects returned in the search results

### QA

When using this against an index with configured redirects do not expect to see redirects returned inside the search results.

### TODO

A separate/duplicate index can be simultaneously searched to handle redirecting e.g.
```
      <Index indexName="integration_catalogue" indexId="redirect_index">
        <Configure tagFilters={"redirect"} hitsPerPage={1} facetFilters={`query_terms:${this.props.query}`} />
        <Hits />
      </Index>
```