### PR TITLE
[0.13.3] Bumped shift-react-components to 0.12.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-next",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "",
   "main": "dist/bundle.js",
   "repository": "https://github.com/shiftcommerce/shift-next.git",
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@shiftcommerce/shift-node-api": "^0.6.1",
-    "@shiftcommerce/shift-react-components": "^0.12.7",
+    "@shiftcommerce/shift-react-components": "^0.12.8",
     "axios": "^0.18.0",
     "js-cookie": "^2.2.0",
     "qs": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "enzyme-adapter-react-16": "^1.9.1",
     "jest": "^24.1.0",
     "jest-enzyme": "^7.0.1",
+    "mockdate": "^2.0.2",
     "next": "^7.0.2",
     "nock": "^10.0.6",
     "redux-mock-store": "^1.5.3",

--- a/test/fixtures/cart.js
+++ b/test/fixtures/cart.js
@@ -103,7 +103,13 @@ const Cart = {
   line_items_count: 2,
   meta_attributes: {},
   shipping_method: {
-    total: 3.45
+    total: 3.45,
+    meta_attributes: {
+      working_days: {
+        data_type: 'text',
+        value: '1'
+      }
+    }
   },
   shipping_total: 3.45,
   shipping_total_discount: 0,

--- a/test/pages/__snapshots__/cart.test.js.snap
+++ b/test/pages/__snapshots__/cart.test.js.snap
@@ -398,7 +398,7 @@ exports[`dispatch updateQuantity action on changing line item quantity 1`] = `
                 className="c-cart-table__description"
               >
                 We will deliver your item: 
-                Monday 21st May
+                Tuesday 21st May
                 .
               </p>
             </div>

--- a/test/pages/__snapshots__/cart.test.js.snap
+++ b/test/pages/__snapshots__/cart.test.js.snap
@@ -380,7 +380,7 @@ exports[`dispatch updateQuantity action on changing line item quantity 1`] = `
                 className="c-cart-table__description"
               >
                 We will deliver your item: 
-                Tuesday 1st January
+                Invalid Date
                 .
               </p>
             </div>

--- a/test/pages/__snapshots__/cart.test.js.snap
+++ b/test/pages/__snapshots__/cart.test.js.snap
@@ -108,6 +108,12 @@ exports[`dispatch updateQuantity action on changing line item quantity 1`] = `
       "line_items_count": 2,
       "meta_attributes": Object {},
       "shipping_method": Object {
+        "meta_attributes": Object {
+          "working_days": Object {
+            "data_type": "text",
+            "value": "1",
+          },
+        },
         "total": 3.45,
       },
       "shipping_total": 3.45,
@@ -237,6 +243,12 @@ exports[`dispatch updateQuantity action on changing line item quantity 1`] = `
             "line_items_count": 2,
             "meta_attributes": Object {},
             "shipping_method": Object {
+              "meta_attributes": Object {
+                "working_days": Object {
+                  "data_type": "text",
+                  "value": "1",
+                },
+              },
               "total": 3.45,
             },
             "shipping_total": 3.45,
@@ -251,6 +263,12 @@ exports[`dispatch updateQuantity action on changing line item quantity 1`] = `
         }
         shippingMethod={
           Object {
+            "meta_attributes": Object {
+              "working_days": Object {
+                "data_type": "text",
+                "value": "1",
+              },
+            },
             "total": 3.45,
           }
         }
@@ -380,7 +398,7 @@ exports[`dispatch updateQuantity action on changing line item quantity 1`] = `
                 className="c-cart-table__description"
               >
                 We will deliver your item: 
-                Invalid Date
+                Monday 21st May
                 .
               </p>
             </div>
@@ -1162,6 +1180,12 @@ exports[`dispatch updateQuantity action on changing line item quantity 1`] = `
                     "line_items_count": 2,
                     "meta_attributes": Object {},
                     "shipping_method": Object {
+                      "meta_attributes": Object {
+                        "working_days": Object {
+                          "data_type": "text",
+                          "value": "1",
+                        },
+                      },
                       "total": 3.45,
                     },
                     "shipping_total": 3.45,

--- a/test/pages/cart.test.js
+++ b/test/pages/cart.test.js
@@ -16,7 +16,7 @@ jest.mock('next/config', () => () => ({
 }))
 
 // Setup mock date for testing business days
-MockDate.set('5/20/2018')
+MockDate.set('5/20/2019')
 
 afterAll(() => {
   MockDate.reset()

--- a/test/pages/cart.test.js
+++ b/test/pages/cart.test.js
@@ -1,8 +1,6 @@
-// Libraries
-import MockDate from 'mockdate'
-
 // Pages
 import CartPage from '../../src/pages/cart'
+import MockDate from 'mockdate'
 
 // Actions
 import { updateLineItemQuantity } from '../../src/actions/cart-actions'
@@ -18,7 +16,7 @@ jest.mock('next/config', () => () => ({
 }))
 
 // Setup mock date for testing business days
-MockDate.set('5/20/2019')
+MockDate.set('5/20/2018')
 
 afterAll(() => {
   MockDate.reset()

--- a/test/pages/cart.test.js
+++ b/test/pages/cart.test.js
@@ -1,3 +1,6 @@
+// Libraries
+import MockDate from 'mockdate'
+
 // Pages
 import CartPage from '../../src/pages/cart'
 
@@ -14,20 +17,11 @@ jest.mock('next/config', () => () => ({
   publicRuntimeConfig: {}
 }))
 
-const RealDate = Date
-const mockDate = new Date('2019-01-01')
-
-beforeAll(() => {
-  global.Date = class extends Date {
-    constructor () {
-      super()
-      return mockDate
-    }
-  }
-})
+// Setup mock date for testing business days
+MockDate.set('5/20/2019')
 
 afterAll(() => {
-  global.Date = RealDate
+  MockDate.reset()
 })
 
 test('dispatch updateQuantity action on changing line item quantity', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -930,13 +930,14 @@
     axios "^0.18.0"
     qs "^6.6.0"
 
-"@shiftcommerce/shift-react-components@^0.12.7":
-  version "0.12.7"
-  resolved "https://registry.yarnpkg.com/@shiftcommerce/shift-react-components/-/shift-react-components-0.12.7.tgz#ca2e41ce57c0880de5ea95c99057f792e178c793"
+"@shiftcommerce/shift-react-components@^0.12.8":
+  version "0.12.8"
+  resolved "https://registry.yarnpkg.com/@shiftcommerce/shift-react-components/-/shift-react-components-0.12.8.tgz#cd13888e1c434e892c7ce949414f580efd1102d3"
+  integrity sha512-A5Xfl30rQjvJgNSUc6PoIzYD6ZxLTd75iMAcRvw6G449gSIucJM85dAZsH+3zS7giJPSQbClDSVfeun9QoHoyQ==
   dependencies:
     classnames "^2.2.6"
+    date-fns "^1.30.1"
     formik "^1.4.0"
-    moment-business-days "^1.1.3"
     react "^16.7.0"
     react-dom "^16.7.0"
     react-input-range "^1.3.0"
@@ -2477,6 +2478,11 @@ data-urls@^1.0.0:
     abab "^2.0.0"
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
+
+date-fns@^1.30.1:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
+  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -5201,9 +5207,10 @@ mkdirp-then@1.2.0:
   dependencies:
     minimist "0.0.8"
 
-moment-business-days@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/moment-business-days/-/moment-business-days-1.1.3.tgz#2922c3ffab8640a84dd27484336a5e0b3c07175a"
+mockdate@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.2.tgz#5ae0c0eaf8fe23e009cd01f9889b42c4f634af12"
+  integrity sha1-WuDA6vj+I+AJzQH5iJtCxPY0rxI=
 
 moment@^2.22.1:
   version "2.24.0"


### PR DESCRIPTION
### Overview

Related GitHub Issue: shiftcommerce/trendy-golf#55

This tiny PR bumps the version of shift-react-components within shift-next. This version pulls in the recent changes in which we replace moment.js with date-fns for performance benefits.

This PR also adds MockDate to shift-next to help with testing dates and updates the cart fixture to include `meta_attributes.working_days`

To see the complete changes to shift-react-components see: https://github.com/shiftcommerce/shift-react-components/pull/52